### PR TITLE
Bump bindgen version to allow cross-compiling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings", "external-ffi-bindings", "network-programming", "o
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.68.1"
 
 [dependencies]
 libc = "0.2.77"


### PR DESCRIPTION
The version of bindgen in Cargo.toml is reaaly old, and doesn't support cross-compilation.

This just bumps the dependency version.

Alternatively, something like `>= 0.55.1,<1.0.0` might allow old versions to work also. I haven't seen any breakage with bindgen versions and they rev minor versions when they really should be reving patch because they're pre-1.0.